### PR TITLE
fix linearDepth

### DIFF
--- a/js/webgpu-renderer/shaders/clustered-compute.js
+++ b/js/webgpu-renderer/shaders/clustered-compute.js
@@ -41,7 +41,7 @@ export const TileFunctions = `
 let tileCount : vec3<u32> = vec3<u32>(${TILE_COUNT[0]}u, ${TILE_COUNT[1]}u, ${TILE_COUNT[2]}u);
 
 fn linearDepth(depthSample : f32) -> f32 {
-  return projection.zNear * projection.zFar / (projection.zFar + projection.zNear - depthSample * (projection.zFar - projection.zNear));
+  return projection.zNear * projection.zFar / (projection.zFar - depthSample * (projection.zFar - projection.zNear));
 }
 
 fn getTile(fragCoord : vec4<f32>) -> vec3<u32> {

--- a/js/webgpu-renderer/shaders/clustered-compute.js
+++ b/js/webgpu-renderer/shaders/clustered-compute.js
@@ -41,7 +41,7 @@ export const TileFunctions = `
 let tileCount : vec3<u32> = vec3<u32>(${TILE_COUNT[0]}u, ${TILE_COUNT[1]}u, ${TILE_COUNT[2]}u);
 
 fn linearDepth(depthSample : f32) -> f32 {
-  return projection.zNear * projection.zFar / (projection.zFar - depthSample * (projection.zFar - projection.zNear));
+  return projection.zFar*projection.zNear / fma(depthSample, projection.zNear-projection.zFar, projection.zFar);
 }
 
 fn getTile(fragCoord : vec4<f32>) -> vec3<u32> {


### PR DESCRIPTION
Current linearDepth function yields values that are greater than nearPlane  and smaller than 0.5*farPlane.
This fix will make linearDepth function return values that are between nearPlane and farPlane.
This fix will not have any impact on rendering because current scene does not have Z-values far enought, the dept slice debug view seems to be exactly same as before, but at least there is one instruction less.

Edit:
I tested that before PR: https://github.com/toji/webgpu-clustered-shading/pull/6 linearDepth was yielding values between nearPlane and farPlane so this PR will restore the correct behavior, but with much simpler formula. 